### PR TITLE
Adding Missing err.response.status and err.status

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,10 @@ const send = require('@polka/send-type')
 
 module.exports = (preErrorHandler = () => {}) => {
   function native (err, req, res) {
-    const status = err.isBoom ? err.output.statusCode : (err.response ? err.response.statusCode : err.statusCode || 500)
+    const status = err.isBoom ? err.output.statusCode
+          : err.response ? (err.response.status || err.response.statusCode)
+            : err.status || 500
+
     const responsePayload = {
       error: HttpStatus.getStatusText(status),
       message: err.isBoom ? err.output.payload.message : err.message,


### PR DESCRIPTION
Trying to use  "http-error-handler" in my swagger-express-middleware base project.
I found out that default errors status use:
error.response.status or error.status

